### PR TITLE
Revert "Add Staticfile and use buildpack path in manifest."

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,4 @@
 ---
 applications:
 - name: game-2048
-  buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+  buildpack: staticfile_buildpack


### PR DESCRIPTION
Reverts bingosummer/2048#1

By default, `staticfile_buildpack` is installed in the latest CF release.
No need to download it from the internet.
